### PR TITLE
Math class witrh sort methods

### DIFF
--- a/src/math/math.h
+++ b/src/math/math.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <types/types.h>
 #include <utility>
 
@@ -167,9 +168,9 @@ public:
     }
     return array;
   }
-  template <typename A>
+  template <typename A, typename Compare = std::less<A>>
   Array<A> sort_internal(Array<A> array, size_t low, size_t high) {
-    std::sort(array.begin()+low, array.begin()+high);
+    std::sort(array.begin()+low, array.begin()+high, Compare());
   return array;
   }
 

--- a/src/math/math.h
+++ b/src/math/math.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <types/types.h>
+#include <utility>
 
 namespace jsfeat {
 class Math {
@@ -41,9 +42,7 @@ public:
           for (ptr = left + 1; ptr <= right; ptr++) {
             for (ptr2 = ptr; ptr2 > left && cmp(array[ptr2], array[ptr2 - 1]);
                  ptr2--) {
-              t = array[ptr2];
-              array[ptr2] = array[ptr2 - 1];
-              array[ptr2 - 1] = t;
+              std::swap(array[ptr2], array[ptr2 - 1]);
             }
           }
           break;
@@ -77,9 +76,7 @@ public:
           pivot = cmp(ta, tb) ? (cmp(tb, tc) ? b : (cmp(ta, tc) ? c : a))
                               : (cmp(tc, tb) ? b : (cmp(ta, tc) ? a : c));
           if (pivot != left0) {
-            t = array[pivot];
-            array[pivot] = array[left0];
-            array[left0] = t;
+            std::swap(array[pivot], array[left0]);
             pivot = left0;
           }
           left = left1 = left0 + 1;
@@ -90,9 +87,7 @@ public:
             while (left <= right && !cmp(ta, array[left])) {
               if (!cmp(array[left], ta)) {
                 if (left > left1) {
-                  t = array[left1];
-                  array[left1] = array[left];
-                  array[left] = t;
+                  std::swap(array[left1], array[left]);
                 }
                 swap_cnt = 1;
                 left1++;
@@ -103,9 +98,7 @@ public:
             while (left <= right && !cmp(array[right], ta)) {
               if (!cmp(ta, array[right])) {
                 if (right < right1) {
-                  t = array[right1];
-                  array[right1] = array[right];
-                  array[right] = t;
+                  std::swap(array[right1], array[right]);
                 }
                 swap_cnt = 1;
                 right1--;
@@ -116,9 +109,7 @@ public:
             if (left > right)
               break;
 
-            t = array[left];
-            array[left] = array[right];
-            array[right] = t;
+            std::swap(array[left], array[right]);
             swap_cnt = 1;
             left++;
             right--;
@@ -141,17 +132,13 @@ public:
           n = std::min((left1 - left0), (left - left1));
           m = (left - n) | 0;
           for (i = 0; i < n; ++i, ++m) {
-            t = array[left0 + i];
-            array[left0 + i] = array[m];
-            array[m] = t;
+            std::swap(array[left0 + i], array[m]);
           }
 
           n = std::min((right0 - right1), (right1 - right));
           m = (right0 - n + 1) | 0;
           for (i = 0; i < n; ++i, ++m) {
-            t = array[left + i];
-            array[left + i] = array[m];
-            array[m] = t;
+            std::swap(array[left + i], array[m]);
           }
           n = (left - left1);
           m = (right1 - right);

--- a/src/math/math.h
+++ b/src/math/math.h
@@ -1,0 +1,191 @@
+#ifndef MATH_H
+#define MATH_H
+
+#include <cstddef>
+#include <types/types.h>
+
+namespace jsfeat {
+class Math {
+public:
+  Math() { qsort_stack.assign(48 * 2, 0); }
+  template <typename A, typename B>
+  Array<A> qsort_internal(Array<A> array, size_t low, size_t high, B (*cmp)(A, A)) {
+    auto isort_thresh = 7;
+    int t, ta, tb, tc;
+    auto sp = 0, left = 0, right = 0, i = 0, n = 0, m = 0, ptr = 0, ptr2 = 0,
+        d = 0;
+    auto left0 = 0, left1 = 0, right0 = 0, right1 = 0, pivot = 0, a = 0, b = 0,
+        c = 0, swap_cnt = 0;
+
+    auto stack = qsort_stack;
+
+    if ((high - low + 1) <= 1) {
+        return array;
+    } 
+
+    stack[0] = low;
+    stack[1] = high;
+
+    while (sp >= 0) {
+
+      left = stack[sp << 1];
+      right = stack[(sp << 1) + 1];
+      sp--;
+
+      for (;;) {
+        n = (right - left) + 1;
+
+        if (n <= isort_thresh) {
+          // insert_sort:
+          for (ptr = left + 1; ptr <= right; ptr++) {
+            for (ptr2 = ptr; ptr2 > left && cmp(array[ptr2], array[ptr2 - 1]);
+                 ptr2--) {
+              t = array[ptr2];
+              array[ptr2] = array[ptr2 - 1];
+              array[ptr2 - 1] = t;
+            }
+          }
+          break;
+        } else {
+          swap_cnt = 0;
+
+          left0 = left;
+          right0 = right;
+          pivot = left + (n >> 1);
+
+          if (n > 40) {
+            d = n >> 3;
+            a = left, b = left + d, c = left + (d << 1);
+            ta = array[a], tb = array[b], tc = array[c];
+            left = cmp(ta, tb) ? (cmp(tb, tc) ? b : (cmp(ta, tc) ? c : a))
+                               : (cmp(tc, tb) ? b : (cmp(ta, tc) ? a : c));
+
+            a = pivot - d, b = pivot, c = pivot + d;
+            ta = array[a], tb = array[b], tc = array[c];
+            pivot = cmp(ta, tb) ? (cmp(tb, tc) ? b : (cmp(ta, tc) ? c : a))
+                                : (cmp(tc, tb) ? b : (cmp(ta, tc) ? a : c));
+
+            a = right - (d << 1), b = right - d, c = right;
+            ta = array[a], tb = array[b], tc = array[c];
+            right = cmp(ta, tb) ? (cmp(tb, tc) ? b : (cmp(ta, tc) ? c : a))
+                                : (cmp(tc, tb) ? b : (cmp(ta, tc) ? a : c));
+          }
+
+          a = left, b = pivot, c = right;
+          ta = array[a], tb = array[b], tc = array[c];
+          pivot = cmp(ta, tb) ? (cmp(tb, tc) ? b : (cmp(ta, tc) ? c : a))
+                              : (cmp(tc, tb) ? b : (cmp(ta, tc) ? a : c));
+          if (pivot != left0) {
+            t = array[pivot];
+            array[pivot] = array[left0];
+            array[left0] = t;
+            pivot = left0;
+          }
+          left = left1 = left0 + 1;
+          right = right1 = right0;
+
+          ta = array[pivot];
+          for (;;) {
+            while (left <= right && !cmp(ta, array[left])) {
+              if (!cmp(array[left], ta)) {
+                if (left > left1) {
+                  t = array[left1];
+                  array[left1] = array[left];
+                  array[left] = t;
+                }
+                swap_cnt = 1;
+                left1++;
+              }
+              left++;
+            }
+
+            while (left <= right && !cmp(array[right], ta)) {
+              if (!cmp(ta, array[right])) {
+                if (right < right1) {
+                  t = array[right1];
+                  array[right1] = array[right];
+                  array[right] = t;
+                }
+                swap_cnt = 1;
+                right1--;
+              }
+              right--;
+            }
+
+            if (left > right)
+              break;
+
+            t = array[left];
+            array[left] = array[right];
+            array[right] = t;
+            swap_cnt = 1;
+            left++;
+            right--;
+          }
+
+          if (swap_cnt == 0) {
+            left = left0, right = right0;
+            // goto insert_sort;
+            for (ptr = left + 1; ptr <= right; ptr++) {
+              for (ptr2 = ptr; ptr2 > left && cmp(array[ptr2], array[ptr2 - 1]);
+                   ptr2--) {
+                t = array[ptr2];
+                array[ptr2] = array[ptr2 - 1];
+                array[ptr2 - 1] = t;
+              }
+            }
+            break;
+          }
+
+          //n = Math.min((left1 - left0), (left - left1));
+          n = std::min((left1 - left0), (left - left1));
+          m = (left - n) | 0;
+          for (i = 0; i < n; ++i, ++m) {
+            t = array[left0 + i];
+            array[left0 + i] = array[m];
+            array[m] = t;
+          }
+
+          //n = Math.min((right0 - right1), (right1 - right));
+          n = std::min((right0 - right1), (right1 - right));
+          m = (right0 - n + 1) | 0;
+          for (i = 0; i < n; ++i, ++m) {
+            t = array[left + i];
+            array[left + i] = array[m];
+            array[m] = t;
+          }
+          n = (left - left1);
+          m = (right1 - right);
+          if (n > 1) {
+            if (m > 1) {
+              if (n > m) {
+                ++sp;
+                stack[sp << 1] = left0;
+                stack[(sp << 1) + 1] = left0 + n - 1;
+                left = right0 - m + 1, right = right0;
+              } else {
+                ++sp;
+                stack[sp << 1] = right0 - m + 1;
+                stack[(sp << 1) + 1] = right0;
+                left = left0, right = left0 + n - 1;
+              }
+            } else {
+              left = left0, right = left0 + n - 1;
+            }
+          } else if (m > 1)
+            left = right0 - m + 1, right = right0;
+          else
+            break;
+        }
+      }
+    }
+    /*for (int &ar: array)
+    std::cout << ar << std::endl;*/
+    return array;
+  }
+
+private:
+  Array<int> qsort_stack;
+};
+} // namespace jsfeat
+#endif

--- a/src/math/math.h
+++ b/src/math/math.h
@@ -1,6 +1,7 @@
 #ifndef MATH_H
 #define MATH_H
 
+#include <algorithm>
 #include <cstddef>
 #include <types/types.h>
 
@@ -13,15 +14,15 @@ public:
     auto isort_thresh = 7;
     int t, ta, tb, tc;
     auto sp = 0, left = 0, right = 0, i = 0, n = 0, m = 0, ptr = 0, ptr2 = 0,
-        d = 0;
+         d = 0;
     auto left0 = 0, left1 = 0, right0 = 0, right1 = 0, pivot = 0, a = 0, b = 0,
-        c = 0, swap_cnt = 0;
+         c = 0, swap_cnt = 0;
 
     auto stack = qsort_stack;
 
     if ((high - low + 1) <= 1) {
-        return array;
-    } 
+      return array;
+    }
 
     stack[0] = low;
     stack[1] = high;
@@ -137,7 +138,6 @@ public:
             break;
           }
 
-          //n = Math.min((left1 - left0), (left - left1));
           n = std::min((left1 - left0), (left - left1));
           m = (left - n) | 0;
           for (i = 0; i < n; ++i, ++m) {
@@ -146,7 +146,6 @@ public:
             array[m] = t;
           }
 
-          //n = Math.min((right0 - right1), (right1 - right));
           n = std::min((right0 - right1), (right1 - right));
           m = (right0 - n + 1) | 0;
           for (i = 0; i < n; ++i, ++m) {
@@ -179,9 +178,12 @@ public:
         }
       }
     }
-    /*for (int &ar: array)
-    std::cout << ar << std::endl;*/
     return array;
+  }
+  template <typename A>
+  Array<A> sort_internal(Array<A> array, size_t low, size_t high) {
+    std::sort(array.begin()+low, array.begin()+high);
+  return array;
   }
 
 private:

--- a/test.cpp
+++ b/test.cpp
@@ -42,4 +42,10 @@ int main() {
   for (int &v : res)
     std::cout << v << " ";
     std::cout << std::endl;
+  std::vector<int> res2 = mat1.sort_internal<int>(vec, 0, vec.size() - 1);
+  // It should print sorted numbers: 4, 7, 9, 17, 21,
+  std::cout << "Sorted numbers:" << std::endl;
+  for (std::vector<int>::iterator it=res2.begin(); it!=res2.end(); ++it)
+    std::cout << *it << " ";
+    std::cout << '\n';
 }

--- a/test.cpp
+++ b/test.cpp
@@ -1,4 +1,5 @@
 #include <cache/Cache.h>
+#include <functional>
 #include <imgproc/imgproc.h>
 #include <math/math.h>
 #include <matrix_t/matrix_t.h>
@@ -37,14 +38,14 @@ int main() {
   Math mat1;
   std::vector<int> vec{17, 9, 4, 7, 21};
   std::vector<int> res = mat1.qsort_internal<int>(vec, 0, vec.size() - 1, myfunction);
-  // It should print sorted numbers: 4, 7, 9, 17, 21,
-  std::cout << "Sorted numbers:" << std::endl;
+  // It should print sorted numbers: 4, 7, 9, 17, 21.
+  std::cout << "Sorted numbers with qsort_internal():" << std::endl;
   for (int &v : res)
     std::cout << v << " ";
     std::cout << std::endl;
-  std::vector<int> res2 = mat1.sort_internal<int>(vec, 0, vec.size() - 1);
-  // It should print sorted numbers: 4, 7, 9, 17, 21,
-  std::cout << "Sorted numbers:" << std::endl;
+  std::vector<int> res2 = mat1.sort_internal<int, std::greater<int>>(vec, 0, vec.size());
+  // It should print sorted numbers: 21, 17, 9, 7, 4.
+  std::cout << "Sorted numbers with sort_internal():" << std::endl;
   for (std::vector<int>::iterator it=res2.begin(); it!=res2.end(); ++it)
     std::cout << *it << " ";
     std::cout << '\n';

--- a/test.cpp
+++ b/test.cpp
@@ -1,16 +1,19 @@
-#include <matrix_t/matrix_t.h>
-#include <types/types.h>
-#include <imgproc/imgproc.h>
-#include <stdlib.h>
 #include <cache/Cache.h>
+#include <imgproc/imgproc.h>
+#include <math/math.h>
+#include <matrix_t/matrix_t.h>
+#include <stdlib.h>
+#include <types/types.h>
 
 using namespace jsfeat;
+
+bool myfunction(int i, int j) { return (i < j); }
 
 int main() {
   matrix_t *src = new matrix_t(2, 2, 0x0100 | 0x04);
   matrix_t *dst = new matrix_t(2, 2, 0x0100 | 0x01);
   src->allocate();
-  u_char some[] = { 23, 20, 12, 24, 212, 220, 120, 46, 78, 92, 35, 12, 120, 120, 120, 120 };
+  u_char some[] = {23, 20, 12, 24, 212, 220, 120, 46, 78, 92, 35, 12, 120, 120, 120, 120};
   dst->allocate();
   imgproc img;
   img.grayscale_m((uintptr_t)src, 2, 2, (uintptr_t)dst, Colors::COLOR_RGBA2GRAY);
@@ -30,5 +33,13 @@ int main() {
   std::cout << "vector cleared" << std::endl;
   // data are not cleared...
   std::cout << (int)d->u8[0] << std::endl;
-
+  std::cout << "Numbers to be sorted: 17, 9, 4, 7, 21." << std::endl;
+  Math mat1;
+  std::vector<int> vec{17, 9, 4, 7, 21};
+  std::vector<int> res = mat1.qsort_internal<int>(vec, 0, vec.size() - 1, myfunction);
+  // It should print sorted numbers: 4, 7, 9, 17, 21,
+  std::cout << "Sorted numbers:" << std::endl;
+  for (int &v : res)
+    std::cout << v << " ";
+    std::cout << std::endl;
 }


### PR DESCRIPTION
I have created a simple **Math** class, with two method **qsort_internal()** and **sort_internal()**. Note that here as with the Cache class the name is in PascaCase. I will follow this convention and other class names will be changed.
**qsort_internal()** is taken from the jsfeat code (and probably derived from [qsort()](https://opensource.apple.com/source/xnu/xnu-1228.0.2/bsd/kern/qsort.c.auto.html). I improved modifing the swapping of elements using the std::swap function.
Probably is better the **sort_internal()** function but i haven't tested with timings.
The functions are templated so very flexibles. I don't think i will implement the emscripten versions, maybe i can do this in another PR. These functions are intended more for internal (C++ code) use.